### PR TITLE
Fix RuntimeError： FlashAttention only support fp16 and bf16 data type 

### DIFF
--- a/inspiremusic/cli/inference.py
+++ b/inspiremusic/cli/inference.py
@@ -72,6 +72,7 @@ class InspireMusicUnified:
         use_cuda = gpu >= 0 and torch.cuda.is_available()
         self.device = torch.device('cuda' if use_cuda else 'cpu')
         self.model = InspireMusic(self.model_dir, load_jit=load_jit, load_onnx=load_onnx, fast=fast, fp16=fp16)
+        self.model.model.llm = self.model.model.llm.to(torch.float16)
 
         logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 

--- a/inspiremusic/llm/llm.py
+++ b/inspiremusic/llm/llm.py
@@ -35,7 +35,7 @@ class SinusoidalEmbedding(nn.Module):
         emb = torch.tensor(log(10000) / (half_dim - 1), device=device)
         emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
         emb = rearrange(x, "i -> i 1") * rearrange(emb, "j -> 1 j")
-        return torch.cat((emb.sin(), emb.cos()), dim=-1).to(torch.float32)
+        return torch.cat((emb.sin(), emb.cos()), dim=-1).to(torch.float16)
 
 class LLM(torch.nn.Module):
     def __init__(


### PR DESCRIPTION
python3.10，torch2.4.1